### PR TITLE
MCASA 53 add index to vuepress

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -29,18 +29,14 @@ module.exports = config({
     "/": {
       lang: "en-US",
     },
-    "/zh/": {
-      title: "Theme Demo",
-      description: "vuepress-theme-hope 的 demo",
-    },
   },
 
   themeConfig: {
     logo: "/logo.svg",
     hostname: "https://vuepress-theme-hope-demo.mrhope.site",
 
-    author: "Mr.Hope",
-    repo: "https://github.com/vuepress-theme-hope/vuepress-theme-hope",
+    author: "Huitzi Solutions",
+    repo: "https://github.com/Huitzi-Solutions/micasa-documentation",
 
     nav: [
       { text: "Home", link: "/home/", icon: "home" },
@@ -66,47 +62,14 @@ module.exports = config({
           title: "Guide",
           icon: "creative",
           prefix: "guide/",
-          children: ["", "page", "markdown", "disable", "encrypt"],
+          children: ["", "1.0 Introduction", "2.0 MCRC Everyday Processes", "3.0 Career Pathway", "4.0 Business Pathway", "5.0 Third Party Integration"],
         },
       ],
     },
 
-    locales: {
-      "/zh/": {
-        nav: [
-          { text: "博客主页", link: "/zh/", icon: "home" },
-          { text: "项目主页", link: "/zh/home/", icon: "home" },
-          {
-            text: "如何使用",
-            icon: "creative",
-            link: "/zh/guide/",
-          },
-          {
-            text: "主题文档",
-            icon: "note",
-            link: "https://vuepress-theme-hope.github.io/zh/",
-          },
-        ],
-        sidebar: {
-          "/zh/": [
-            "",
-            "home",
-            "slides",
-            "layout",
-            {
-              title: "如何使用",
-              icon: "creative",
-              prefix: "guide/",
-              children: ["", "page", "markdown", "disable", "encrypt"],
-            },
-          ],
-        },
-      },
-    },
-
     footer: {
       display: true,
-      content: "默认页脚",
+      content: "2021 Mi Casa Resource Center",
     },
 
     comment: {
@@ -119,7 +82,7 @@ module.exports = config({
     },
 
     git: {
-      timezone: "Asia/Shanghai",
+      timezone: "Mountain-Time/Denver",
     },
 
     mdEnhance: {

--- a/docs/guide/readme.md
+++ b/docs/guide/readme.md
@@ -3,12 +3,14 @@ icon: creative
 category: Guide
 ---
 
-# Guides
+# Index
 
-- [Page Config](page.md)
+- [1.0 Introduction](page.md)
 
-- [Markdown Enhance](markdown.md)
+- [2.0 MCRC Everyday Processes](markdown.md)
 
-- [Function Disable](disable.md)
+- [3.0 Career Pathway](disable.md)
 
-- [Encryption Demo](encrypt.md)
+- [4.0 Business Pathway](encrypt.md)
+
+- [5.0 Third Party Integrations](encrypt.md)

--- a/docs/home.md
+++ b/docs/home.md
@@ -12,57 +12,25 @@ action:
     type: primary
 
 features:
-  - title: Markdown Enhance 🧰
+  - title: 1.0 How to use this guide
     details: Add align, sup/sub script, footnote, tasklist, tex, flowchart, diagram, mark and presentation support in Markdown
     link: https://vuepress-theme-hope.github.io/guide/markdown/
 
-  - title: Pageviews and comments 💬
+  - title: 2.0 MCRC Everyday processes
     details: Start pageview statistics and comment support with Valine and Vssue
     link: https://vuepress-theme-hope.github.io/guide/feature/comment/
 
-  - title: Article information display ℹ
+  - title: 3.0 Career Pathway
     details: Add author, writing date, reading time, word count and other information to your article
     link: https://vuepress-theme-hope.github.io/guide/feature/page-info/
 
-  - title: Blog support 📝
+  - title: 4.0 Business Pathway
     details: Add date, tags and category to your articles, then article, tag, category and timeline list will be auto generated
     link: https://vuepress-theme-hope.github.io/guide/blog/intro/
 
-  - title: Article Encryption 🔐
+  - title: 5.0 Third Party Integration
     details: Encrypt you article based on path and folders, so that only the one you want could see them
     link: https://vuepress-theme-hope.github.io/guide/feature/encrypt/
-
-  - title: Custom theme color 🎨
-    details: Supports custom theme colors and allows users to switch between preset theme colors
-    link: https://vuepress-theme-hope.github.io/guide/interface/theme-color/
-
-  - title: Dark Mode 🌙
-    details: Switch between light and dark modes freely
-    link: https://vuepress-theme-hope.github.io/guide/interface/darkmode/
-
-  - title: SEO enhancement ⚒
-    details: Optimize pages for search engines.
-    link: https://vuepress-theme-hope.github.io/guide/feature/seo/
-
-  - title: Sitemap 🗺
-    details: Generate a Sitemap for your website
-    link: https://vuepress-theme-hope.github.io/guide/feature/sitemap/
-
-  - title: Feed support 📡
-    details: You can generate feed, and let users to subcribe it
-    link: https://vuepress-theme-hope.github.io/guide/feature/feed/
-
-  - title: PWA support 📲
-    details: The built-in PWA plugin will make your website more like an APP.
-    link: https://vuepress-theme-hope.github.io/guide/feature/pwa/
-
-  - title: TS support 🔧
-    details: Turn on TypeScript support for your VuePress
-    link: https://vuepress-theme-hope.github.io/guide/feature/typescript/
-
-  - title: More new features ✨
-    details: Including icon support, path navigation, footer support, fullscreen button, blog homepage, etc.
-    link: https://vuepress-theme-hope.github.io/guide/feature/
 
 copyrightText: false
 footer: MIT Licensed | Copyright © 2019-present Mr. Hope

--- a/docs/home.md
+++ b/docs/home.md
@@ -1,17 +1,15 @@
 ---
 home: true
+blog: false
 icon: home
-title: Project home
+title: Mi Casa's Salesforce Documentation
 heroImage: /logo.svg
-heroText: Project name
-tagline: You can place the description of the project here.
+heroText: Salesforce Documentation
+tagline: Find tutorials, developer,admin and user guides.
 action:
-  - text: How to Use 💡
+  - text: How to Use this guide
     link: /guide/
     type: primary
-
-  - text: Blog homepage 🏠
-    link: /
 
 features:
   - title: Markdown Enhance 🧰

--- a/docs/home.md
+++ b/docs/home.md
@@ -14,30 +14,26 @@ action:
 features:
   - title: 1.0 How to use this guide
     details: Add align, sup/sub script, footnote, tasklist, tex, flowchart, diagram, mark and presentation support in Markdown
-    link: https://vuepress-theme-hope.github.io/guide/markdown/
+    link: /guide/markdown/
 
   - title: 2.0 MCRC Everyday processes
     details: Start pageview statistics and comment support with Valine and Vssue
-    link: https://vuepress-theme-hope.github.io/guide/feature/comment/
+    link: /guide/feature/comment/
 
   - title: 3.0 Career Pathway
     details: Add author, writing date, reading time, word count and other information to your article
-    link: https://vuepress-theme-hope.github.io/guide/feature/page-info/
+    link: /guide/feature/page-info/
 
   - title: 4.0 Business Pathway
     details: Add date, tags and category to your articles, then article, tag, category and timeline list will be auto generated
-    link: https://vuepress-theme-hope.github.io/guide/blog/intro/
+    link: /guide/blog/intro/
 
   - title: 5.0 Third Party Integration
     details: Encrypt you article based on path and folders, so that only the one you want could see them
-    link: https://vuepress-theme-hope.github.io/guide/feature/encrypt/
+    link: /guide/feature/encrypt/
 
 copyrightText: false
-footer: MIT Licensed | Copyright © 2019-present Mr. Hope
+footer: Copyright © 2021 Mi Casa Resource Center
 ---
 
-This is an example of a normal homepage. You can place your main content here.
-
-To use this layout, you need to set `home: true` in the page front matter.
-
-For related descriptions of configuration items, please see [Project HomePage Layout Config](https://vuepress-theme-hope.github.io/guide/layout/home/).
+This guide is intended to inform Salesforce users, administrators, and developers of the current configuration, features, and automations active in Mi Casa’s Salesforce org. This is meant to be a living document where every change, addition and/or update to the org will be documented.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -4,8 +4,8 @@ home: true
 icon: home
 title: Mi Casa's Salesforce Documentation
 heroImage: /logo.svg
-heroText: Find tutorials, developer,admin and user guides.
-tagline: Mi Casa's Salesforce Org
+heroText: Salesforce Org Documentation
+tagline: Find tutorials, developer,admin and user guides.
 heroFullScreen: true
 project:
   - type: project
@@ -28,11 +28,7 @@ project:
     desc: Detailed description of the article
     link: https://link.to.your.article
 
-footer: customize your footer text
+footer: Copyright © 2021 Mi Casa Resource Center
 ---
 
-This is a blog home page.
-
-To use this layout, you should set both `blog: true` and `home: true` in the page front matter.
-
-For related configuration docs, please see [blog homepage](https://vuepress-theme-hope.github.io/guide/blog/home/)
+This guide is intended to inform Salesforce users, administrators, and developers of the current configuration, features, and automations active in Mi Casa’s Salesforce org. This is meant to be a living document where every change, addition and/or update to the org will be documented.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -2,10 +2,10 @@
 blog: false
 home: true
 icon: home
-title: Blog Home
+title: Mi Casa's Salesforce Documentation
 heroImage: /logo.svg
-heroText: the name of your blog
-tagline: You can put your slogan here
+heroText: Find tutorials, developer,admin and user guides.
+tagline: Mi Casa's Salesforce Org
 heroFullScreen: true
 project:
   - type: project


### PR DESCRIPTION
- Add index to the main page of documentation. In this case "Readme.md" and "Home.md"
- Add introductory texts to all home pages
- Change descriptions on the sitemap for navigating pages
- Add the corresponding pages for the documentation
- Delete all configurations related to navigation and index that were demo purposes for the theme and they no longer work